### PR TITLE
Add linkable strings and IDs to languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # misc
 .DS_Store
+/.vscode/
 
 # debug
 npm-debug.log*

--- a/lib.ts
+++ b/lib.ts
@@ -1,4 +1,5 @@
 type version = 6 | 7 | 8 | 9 | string
+export type LinkableString = string | { text: string; url: string }
 
 export interface Lib {
 	name: string
@@ -6,10 +7,10 @@ export interface Lib {
 	language: string
 	apiVer: version
 	gwVer: version
-	slashCommands: string
-	buttons: string
-	selectMenus: string
-	threads: string
-	guildStickers: string
-	contextMenus: string
+	slashCommands: LinkableString
+	buttons: LinkableString
+	selectMenus: LinkableString
+	threads: LinkableString
+	guildStickers: LinkableString
+	contextMenus: LinkableString
 }

--- a/libs.ts
+++ b/libs.ts
@@ -27,8 +27,14 @@ export const libs: Lib[] = [
 		slashCommands: 'Yes',
 		buttons: 'Yes',
 		selectMenus: 'Yes',
-		threads: 'Has a PR',
-		guildStickers: 'Has a PR',
+		threads: {
+			text: 'Has a PR',
+			url: 'https://github.com/DisgoOrg/disgo/pull/17'
+		},
+		guildStickers: {
+			text: 'Has a PR',
+			url: 'https://github.com/DisgoOrg/disgo/pull/63'
+		},
 		contextMenus: 'Yes'
 	},
 	{

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -108,15 +108,6 @@ export default function Home() {
 					align-items: center;
 				}
 
-				a {
-					color: #00aff4;
-				}
-
-				a:hover {
-					color: #00aff4;
-					text-decoration: underline;
-				}
-
 				#title {
 					margin: 0;
 					line-height: 1.15;
@@ -161,6 +152,15 @@ export default function Home() {
 						Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue,
 						sans-serif;
 					background: #36393f;
+				}
+
+				a {
+					color: #00aff4;
+				}
+
+				a:hover {
+					color: #00aff4;
+					text-decoration: underline;
 				}
 
 				.table td, .table th {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head'
+import { LinkableString } from '../lib'
 
 import { libs } from '../libs'
 
@@ -9,7 +10,9 @@ const statusColors = {
 	No: 'danger'
 }
 
-const status = (status: string) => <td className={`has-background-${statusColors[status] ?? 'warning-dark'}`}>{status}</td>
+const status = (status: LinkableString) => typeof status === 'string'
+	? <td className={`has-background-${statusColors[status] ?? 'warning-dark'}`}>{status}</td>
+	: <td className={`has-background-${statusColors[status.text] ?? 'warning-dark'}`}><a href={status.url} target="_blank" rel="noopener">{status.text}</a></td>
 
 const versionColors = {
 	6: 'danger',
@@ -35,7 +38,7 @@ export default function Home() {
 				</h1>
 
 				{langs.map(lang => <div key={lang} className="mb-4 fw">
-					<h2 className="title is-4 mb-3 has-text-white">{lang}</h2>
+					<h2 id={lang.toLowerCase()} className="title is-4 mb-3 has-text-white">{lang}</h2>
 
 					<div className="table-container">
 						<table className="table is-bordered mb-4 has-text-centered has-text-white fw">


### PR DESCRIPTION
Allows some table cells to be linked and puts `id`s in language headers to be able to jump to them

For some reason the styling won't apply to the table cells that the `status()` function made, making the links look bad, not sure how to fix that