### PR TITLE
add arikawa

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -58,6 +58,19 @@ export const libs: Lib[] = [
 		contextMenus: 'No'
 	},
 	{
+		name: 'arikawa',
+		url: 'https://github.com/diamondburned/arikawa',
+		language: 'Go',
+		apiVer: 9,
+		gwVer: 9,
+		slashCommands: 'Yes',
+		buttons: 'Yes',
+		selectMenus: 'Yes',
+		threads: 'Yes',
+		guildStickers: 'Yes',
+		contextMenus: 'Yes'
+	},
+	{
 		name: 'DiscordGo',
 		url: 'https://github.com/bwmarrin/discordgo',
 		language: 'Go',


### PR DESCRIPTION
arikawa is a library for the Discord API in Go. arikawa has multiple layers of abstraction and a clean separation between the gateway and REST APIs, so you can go as high-level or low-level as you want. It has pluggable state storage, giving you full control over how much data to cache and where to cache it.