### PR TITLE
nyxx: update scheduled events state

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -216,10 +216,7 @@ export const libs: Lib[] = [
 		guildStickers: 'Yes',
 		contextMenus: 'Yes',
 		autocomplete: 'Yes',
-		scheduledEvents: {
-			text: 'Has a PR',
-			url: 'https://github.com/nyxx-discord/nyxx/pull/248'
-		}
+		scheduledEvents: 'Dev Version'
 	},
 	{
 		name: 'coxir',


### PR DESCRIPTION
Today PR with scheduled events was merged into `next` brach so feature is now accessible in dev version.

Also thanks for adding my lib. I was going to do that today and I was a little suprised that it was already there :)