### PR TITLE
Change `@import` to `@use`

### DIFF
--- a/bulma.sass
+++ b/bulma.sass
@@ -1,13 +1,13 @@
-@import "bulma/sass/utilities/initial-variables"
-@import "bulma/sass/utilities/controls"
-@import "bulma/sass/utilities/extends"
+@use "bulma/sass/utilities/initial-variables";
+@use "bulma/sass/utilities/controls";
+@use "bulma/sass/utilities/extends";
 
-@import "bulma/sass/base/minireset"
-@import "bulma/sass/base/generic"
+@use "bulma/sass/base/minireset";
+@use "bulma/sass/base/generic";
 
-@import "bulma/sass/elements/table"
-@import "bulma/sass/elements/title"
+@use "bulma/sass/elements/table";
+@use "bulma/sass/elements/title";
 
-@import "bulma/sass/helpers/color"
-@import "bulma/sass/helpers/spacing"
-@import "bulma/sass/helpers/typography"
+@use "bulma/sass/helpers/color";
+@use "bulma/sass/helpers/spacing";
+@use "bulma/sass/helpers/typography";

--- a/bulma.sass
+++ b/bulma.sass
@@ -1,13 +1,13 @@
-@use "bulma/sass/utilities/initial-variables";
-@use "bulma/sass/utilities/controls";
-@use "bulma/sass/utilities/extends";
+@use "bulma/sass/utilities/initial-variables"
+@use "bulma/sass/utilities/controls"
+@use "bulma/sass/utilities/extends"
 
-@use "bulma/sass/base/minireset";
-@use "bulma/sass/base/generic";
+@use "bulma/sass/base/minireset"
+@use "bulma/sass/base/generic"
 
-@use "bulma/sass/elements/table";
-@use "bulma/sass/elements/title";
+@use "bulma/sass/elements/table"
+@use "bulma/sass/elements/title"
 
-@use "bulma/sass/helpers/color";
-@use "bulma/sass/helpers/spacing";
-@use "bulma/sass/helpers/typography";
+@use "bulma/sass/helpers/color"
+@use "bulma/sass/helpers/spacing"
+@use "bulma/sass/helpers/typography"


### PR DESCRIPTION
The `@import` rule is about to be depricated and is no longer recommended to import modules. Sass now officially recommends the use of `@use` instead of the former.

Reference: https://sass-lang.com/documentation/at-rules/import (check the "Heads Up" section of this page)