### PR TITLE
Update DiscordPHP

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -626,23 +626,20 @@ export const libs: Lib[] = [
 		name: 'DiscordPHP',
 		url: 'https://github.com/discord-php/DiscordPHP',
 		language: 'PHP',
-		apiVer: 8,
-		gwVer: 8,
-		slashCommands: 'No',
-		buttons: 'Yes',
-		selectMenus: 'Yes',
-		threads: 'Yes',
+		apiVer: '8, 9 dev',
+		gwVer: '8, 9 dev',
+		slashCommands: {
+			text: 'Has a PR',
+			url: 'https://github.com/discord-php/DiscordPHP/pull/597'
+		},
+		buttons: 'Dev Version',
+		selectMenus: 'Dev Version',
+		threads: 'Dev Version',
 		guildStickers: 'Yes',
 		contextMenus: 'No',
 		autocomplete: 'No',
-		scheduledEvents: {
-			text: 'Has a PR',
-			url: 'https://github.com/discord-php/DiscordPHP/pull/648'
-		},
-		timeouts: {
-			text: 'Has a PR',
-			url: 'https://github.com/discord-php/DiscordPHP/pull/650'
-		}
+		scheduledEvents: 'Dev Version',
+		timeouts: 'Dev Version'
 	},
 	{
 		name: 'RestCord',

--- a/libs.ts
+++ b/libs.ts
@@ -626,8 +626,8 @@ export const libs: Lib[] = [
 		name: 'DiscordPHP',
 		url: 'https://github.com/discord-php/DiscordPHP',
 		language: 'PHP',
-		apiVer: '8, 9 dev',
-		gwVer: '8, 9 dev',
+		apiVer: '8 stable, 9 dev',
+		gwVer: '8 stable, 9 dev',
 		slashCommands: {
 			text: 'Has a PR',
 			url: 'https://github.com/discord-php/DiscordPHP/pull/597'

--- a/libs.ts
+++ b/libs.ts
@@ -636,8 +636,14 @@ export const libs: Lib[] = [
 		selectMenus: 'Dev Version',
 		threads: 'Dev Version',
 		guildStickers: 'Yes',
-		contextMenus: 'No',
-		autocomplete: 'No',
+		contextMenus: {
+			text: 'Has a PR',
+			url: 'https://github.com/discord-php/DiscordPHP/pull/597'
+		},
+		autocomplete: {
+			text: 'Has a PR',
+			url: 'https://github.com/discord-php/DiscordPHP/pull/597'
+		},
 		scheduledEvents: 'Dev Version',
 		timeouts: 'Dev Version'
 	},


### PR DESCRIPTION
The Dev Version `dev-master` a.k.a. dphp [v7.0.0](https://github.com/discord-php/DiscordPHP/blob/20855e76d8b71a34bea7cc61653f30024a6f9ee6/src/Discord/Discord.php#L88), uses [API](https://github.com/discord-php/DiscordPHP-Http/blob/71064fcaf769097d34917a17baefe10d477a5f23/src/Discord/Http.php#L47) [Gateway v9](https://github.com/discord-php/DiscordPHP/blob/20855e76d8b71a34bea7cc61653f30024a6f9ee6/src/Discord/Discord.php#L81), stable a.k.a dphp v6.0.3 uses v8
Slash command is also in the work (with autocomplete & context menu), despite DiscordPHP-Slash addon ["is back working again"](https://github.com/discord-php/DiscordPHP-Slash/pull/14), it will be merged with the [PR 597](https://github.com/discord-php/DiscordPHP/pull/597) 
Also correcting that message components buttons & select menus & threads is still on dev version
Scheduled event [PR](https://github.com/discord-php/DiscordPHP/pull/648)  & timeout [PR](https://github.com/discord-php/DiscordPHP/pull/650) has been also merged to dev version recently