### PR TITLE
add slshx

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -599,6 +599,23 @@ export const libs: Lib[] = [
 		}
 	},
 	{
+		name: 'Slshx',
+		url: 'https://github.com/mrbbot/slshx',
+		language: 'JavaScript',
+		apiVer: 9,
+		gwVer: '-',
+		slashCommands: 'Yes',
+		buttons: 'Yes',
+		selectMenus: 'Yes',
+		threads: '-',
+		guildStickers: '-',
+		contextMenus: 'Yes',
+		autocomplete: 'Yes',
+		scheduledEvents: '-',
+		timeouts: '-',
+		modals: 'Yes'
+	},
+	{
 		name: 'SnowTransfer',
 		url: 'https://github.com/DasWolke/SnowTransfer',
 		language: 'JavaScript',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,7 +7,8 @@ const langs = Array.from(new Set(libs.map(lib => lib.language).sort()))
 
 const statusColors = {
 	Yes: 'green',
-	No: 'red'
+	No: 'red',
+	'-': 'gray'
 }
 
 const status = (status: LinkableString) => typeof status === 'string'


### PR DESCRIPTION
Adds [slshx](https://github.com/mrbbot/slshx) to the list of libraries. Slshx is an http interactions only library (designed for CloudFlare workers) so I used `-` for the non applicable features and added a rule to color `-` gray. If there is a different way you would like to handle http interactions only libraries, please let me know.