### PR TITLE
Nextcord uses HTTP API v9

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -855,7 +855,7 @@ export const libs: Lib[] = [
 		name: 'nextcord 🍴',
 		url: 'https://github.com/nextcord/nextcord',
 		language: 'Python',
-		apiVer: 8,
+		apiVer: 9,
 		gwVer: 9,
 		slashCommands: 'Yes',
 		buttons: 'Yes',


### PR DESCRIPTION
Please note that nextcord also has a PR open for API v10 (https://github.com/nextcord/nextcord/pull/464)  however apiVer is a version not linkableString so not quite sure how you would do it.