### PR TITLE
Update Discord4J info

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -425,15 +425,18 @@ export const libs: Lib[] = [
 			text: 'Dev Version',
 			url: 'https://github.com/Discord4J/Discord4J/issues/958'
 		},
-		guildStickers: 'No',
+		guildStickers: {
+			text: 'Has a PR',
+			url: 'https://github.com/Discord4J/Discord4J/pull/1055'
+		},
 		contextMenus: 'Yes',
 		autocomplete: 'Yes',
 		scheduledEvents: {
 			text: 'Has a PR',
 			url: 'https://github.com/Discord4J/Discord4J/pull/1046'
 		},
-		timeouts: 'Dev Version',
-		modals: 'Dev Version'
+		timeouts: 'Yes',
+		modals: 'Yes'
 	},
 	{
 		name: 'Javacord',


### PR DESCRIPTION
This updates and corrects some info related to d4j:
- guild sticker PR
- stable support for timeouts and modals