### PR TITLE
rename and move dis-snek

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -791,23 +791,6 @@ export const libs: Lib[] = [
 		modals: 'Yes'
 	},
 	{
-		name: 'dis-snek',
-		url: 'https://github.com/Discord-Snake-Pit/Dis-Snek',
-		language: 'Python',
-		apiVer: '9 stable, 10 dev',
-		gwVer: '9 stable, 10 dev',
-		slashCommands: 'Yes',
-		buttons: 'Yes',
-		selectMenus: 'Yes',
-		threads: 'Yes',
-		guildStickers: 'Yes',
-		contextMenus: 'Yes',
-		autocomplete: 'Yes',
-		scheduledEvents: 'Yes',
-		timeouts: 'Yes',
-		modals: 'Yes'
-	},
-	{
 		name: 'enhanced-discord.py 🍴',
 		url: 'https://github.com/iDevision/enhanced-discord.py',
 		language: 'Python',
@@ -866,6 +849,23 @@ export const libs: Lib[] = [
 			text: 'Has a PR',
 			url: 'https://github.com/hikari-py/hikari/pull/1002'
 		}
+	},
+	{
+		name: 'NAFF',
+		url: 'https://github.com/NAFTeam/NAFF',
+		language: 'Python',
+		apiVer: '10',
+		gwVer: '10',
+		slashCommands: 'Yes',
+		buttons: 'Yes',
+		selectMenus: 'Yes',
+		threads: 'Yes',
+		guildStickers: 'Yes',
+		contextMenus: 'Yes',
+		autocomplete: 'Yes',
+		scheduledEvents: 'Yes',
+		timeouts: 'Yes',
+		modals: 'Yes'
 	},
 	{
 		name: 'nextcord 🍴',


### PR DESCRIPTION
Dis-Snek renamed to NAFF to avoid naming conflicts with other libraries. This PR reflects this, moves NAFF to its proper location, and updates API versions.