### PR TITLE
Move i.py to its correct pos

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -740,23 +740,6 @@ export const libs: Lib[] = [
 		modals: 'No'
 	},
 	{
-		name: 'interactions.py',
-		url: 'https://github.com/interactions-py/library',
-		language: 'Python',
-		apiVer: 10,
-		gwVer: 10,
-		slashCommands: 'Yes',
-		buttons: 'Yes',
-		selectMenus: 'Yes',
-		threads: 'Yes',
-		guildStickers: 'Yes',
-		contextMenus: 'Yes',
-		autocomplete: 'Yes',
-		scheduledEvents: 'Yes',
-		timeouts: 'Yes',
-		modals: 'Yes'
-	},
-	{
 		name: 'discord.py',
 		url: 'https://github.com/Rapptz/discord.py',
 		language: 'Python',
@@ -866,6 +849,23 @@ export const libs: Lib[] = [
 			text: 'Has a PR',
 			url: 'https://github.com/hikari-py/hikari/pull/1002'
 		}
+	},
+	{
+		name: 'interactions.py',
+		url: 'https://github.com/interactions-py/library',
+		language: 'Python',
+		apiVer: 10,
+		gwVer: 10,
+		slashCommands: 'Yes',
+		buttons: 'Yes',
+		selectMenus: 'Yes',
+		threads: 'Yes',
+		guildStickers: 'Yes',
+		contextMenus: 'Yes',
+		autocomplete: 'Yes',
+		scheduledEvents: 'Yes',
+		timeouts: 'Yes',
+		modals: 'Yes'
 	},
 	{
 		name: 'nextcord 🍴',


### PR DESCRIPTION
Interactions.py used to be known as `discord-py-slash-commands`, when it was renamed, it wasnt moved to its correct position. This PR fixes that. 

cc @DeltaXWizard 