### PR TITLE
refactor(nextcord): change automod to new PR URL

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -1126,7 +1126,7 @@ export const libs: Lib[] = [
 		permsv2: 'Yes',
 		automod: {
 			text: 'Has a PR',
-			url: 'https://github.com/nextcord/nextcord/pull/682'
+			url: 'https://github.com/nextcord/nextcord/pull/740'
 		},
 		localization: 'Yes'
 	},


### PR DESCRIPTION
This changes the AutoMod pull request URL for nextcord to the new pull request URL as the first one was closed.