### PR TITLE
Update automod and permsv2 for DiscordGo

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -432,8 +432,8 @@ export const libs: Lib[] = [
 		scheduledEvents: 'Yes',
 		timeouts: 'Yes',
 		modals: 'Yes',
-		permsv2: 'Dev Version',
-		automod: 'Dev Version',
+		permsv2: 'Yes',
+		automod: 'Yes',
 		localization: 'Yes'
 	},
 	{


### PR DESCRIPTION
DiscordGo v0.26.0 adds support for Automod and PermsV2: https://github.com/bwmarrin/discordgo/releases/tag/v0.26.0