### PR TITLE
eris: update timeout support

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -772,7 +772,7 @@ export const libs: Lib[] = [
 			text: 'Has a PR',
 			url: 'https://github.com/abalabahaha/eris/pull/1275'
 		},
-		timeouts: 'Dev Version',
+		timeouts: 'Yes',
 		modals: 'No',
 		permsv2: {
 			text: 'Has a PR',


### PR DESCRIPTION
Timeouts are supported by stable Eris since [v0.17.0](https://github.com/abalabahaha/eris/releases/tag/0.17.0).