### PR TITLE
chore: update interactions.py's forum support status 

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -1155,7 +1155,7 @@ export const libs: Lib[] = [
 		permsv2: 'Yes',
 		automod: 'Yes',
 		localization: 'Yes',
-		forums: 'Dev Version'
+		forums: 'Yes'
 	},
 	{
 		name: 'NAFF',


### PR DESCRIPTION
This updates the state of interactions.py's forum support from "dev-version" to "yes", since it has been [released](https://github.com/interactions-py/library/releases/tag/4.3.2) to pip on October 4th