### PR TITLE
Hikari fully supports threads in release v2.0.0.dev113

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -1127,7 +1127,7 @@ export const libs: Lib[] = [
 		slashCommands: 'Yes',
 		buttons: 'Yes',
 		selectMenus: 'Partial',
-		threads: 'Dev Version',
+		threads: 'Yes',
 		guildStickers: 'Yes',
 		contextMenus: 'Yes',
 		autocomplete: 'Yes',


### PR DESCRIPTION
Since dev113 threads including the cache impl were released. Idk why this was changed to "Dev Version."
https://github.com/hikari-py/hikari/releases/tag/2.0.0.dev113