### PR TITLE
fix(nextcord): module now fully supports selects

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -1192,7 +1192,7 @@ export const libs: Lib[] = [
 		gwVer: 10,
 		slashCommands: 'Yes',
 		buttons: 'Yes',
-		selectMenus: 'Partial',
+		selectMenus: 'Yes',
 		threads: 'Yes',
 		guildStickers: 'Yes',
 		contextMenus: 'Yes',


### PR DESCRIPTION
Nextcord fully supports Select Menus as of v2.3 of the package.