### PR TITLE
Update ids to use url safe characters

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -41,7 +41,7 @@ export default function Home() {
 				</h1>
 
 				{langs.map(lang => <div key={lang} className="mb-4 fw">
-					<h2 id={lang.toLowerCase()} className="title is-4 mb-3 has-text-white"><a href={'#' + lang.toLowerCase()}>{lang}</a></h2>
+					<h2 id={encodeURIComponent(lang.toLowerCase())} className="title is-4 mb-3 has-text-white"><a href={'#' + encodeURIComponent(lang.toLowerCase())}>{lang}</a></h2>
 
 					<div className="table-container">
 						<table className="table is-bordered mb-4 has-text-centered has-text-white fw">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -41,7 +41,7 @@ export default function Home() {
 				</h1>
 
 				{langs.map(lang => <div key={lang} className="mb-4 fw">
-					<h2 id={encodeURIComponent(lang.toLowerCase())} className="title is-4 mb-3 has-text-white"><a href={'#' + encodeURIComponent(lang.toLowerCase())}>{lang}</a></h2>
+					<h2 id={lang.toLowerCase()} className="title is-4 mb-3 has-text-white"><a href={'#' + encodeURIComponent(lang.toLowerCase())}>{lang}</a></h2>
 
 					<div className="table-container">
 						<table className="table is-bordered mb-4 has-text-centered has-text-white fw">


### PR DESCRIPTION
This updates the ids of elements so they use url safe characters (ex. `c#` becomes `c%23`), and won't cause issues such as the following when trying to link to a certain header:
![IMG_2997](https://user-images.githubusercontent.com/46201432/226165839-b927a5b3-f2b4-4dad-8469-3d6c11847c4b.jpg)
