### PR TITLE
update dnet forwarding support

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -106,10 +106,7 @@ export const libs: Lib[] = [
 		monetization: 'Yes',
 		userApps: 'Yes',
 		polls: 'Yes',
-		forwarding: {
-			text: 'Has a PR',
-			url: 'https://github.com/discord-net/Discord.Net/pull/2918'
-		},
+		forwarding: 'Yes',
 		appEmoji: 'Yes'
 	},
 	{


### PR DESCRIPTION
Message forwards supported since [3.16.0](https://github.com/discord-net/Discord.Net/releases/tag/3.16.0)