### PR TITLE
discordia: threads and stickers

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -1278,8 +1278,11 @@ export const libs: Lib[] = [
 		slashCommands: 'No',
 		buttons: 'No',
 		selectMenus: 'No',
-		threads: 'No',
-		guildStickers: 'No',
+		threads: {
+			text: 'Has a PR',
+			url: 'https://github.com/SinisterRectus/Discordia/pull/418'
+		},
+		guildStickers: 'Yes',
 		contextMenus: 'No',
 		autocomplete: 'No',
 		scheduledEvents: 'No',


### PR DESCRIPTION
Guild stickers were added in https://github.com/SinisterRectus/Discordia/pull/389, released in version 2.12.0.

Threads are currently waiting on PR https://github.com/SinisterRectus/Discordia/pull/418, which will also bump the API version to 9.