### PR TITLE
Update hikari's automod status

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -1678,10 +1678,7 @@ export const libs: Lib[] = [
 		timeouts: 'Yes',
 		modals: 'Yes',
 		permsv2: 'Yes',
-		automod: {
-			text: 'Has a PR',
-			url: 'https://github.com/hikari-py/hikari/pull/2205'
-		},
+		automod: 'Yes',
 		localization: 'Yes',
 		forums: 'Yes',
 		monetization: 'Partial',


### PR DESCRIPTION
Merged as https://github.com/hikari-py/hikari/commit/86dfd7f4e4aaa2a37a07727c56d9f70b2d4199fb and will be available in `2.3.1` (which will be going out later today)