### PR TITLE
chore: update dysnomia status for components v2

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -1059,10 +1059,7 @@ export const libs: Lib[] = [
 		polls: 'Yes',
 		forwarding: 'Yes',
 		appEmoji: 'Yes',
-		componentsV2: {
-			text: 'Has a PR',
-			url: 'https://github.com/projectdysnomia/dysnomia/pull/194'
-		}
+		componentsV2: 'Yes'
 	},
 	{
 		name: 'Eris',


### PR DESCRIPTION
Dysnomia supports components V2 in v0.2.3.

Ref: https://github.com/projectdysnomia/dysnomia/releases/tag/v0.2.3