### PR TITLE
Updated DiscordGo and Discord4j state

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -589,11 +589,11 @@ export const libs: Lib[] = [
 		localization: 'Yes',
 		forums: 'Yes',
 		monetization: 'Dev Version',
-		userApps: 'Dev Version',
-		polls: 'Dev Version',
+		userApps: 'Yes',
+		polls: 'Yes',
 		forwarding: 'No',
 		appEmoji: 'Dev Version',
-		componentsV2: 'No'
+		componentsV2: 'Yes'
 	},
 	{
 		name: 'disgo',
@@ -798,8 +798,8 @@ export const libs: Lib[] = [
 		name: 'Discord4J',
 		url: 'https://github.com/Discord4J/Discord4J',
 		language: 'Java',
-		apiVer: '8 stable, 9 dev',
-		gwVer: '8 stable, 9 dev',
+		apiVer: '10',
+		gwVer: '10',
 		voiceVer: 4,
 		slashCommands: 'Yes',
 		buttons: 'Yes',


### PR DESCRIPTION
Components v2, pols, user apps in DiscordGo is now available in v0.29.0, and Discord4j uses API Version V10, not V8