### PR TITLE
Include Tempest (Go) library

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -715,7 +715,7 @@ export const libs: Lib[] = [
 		monetization: 'Partial',
 		userApps: 'Yes',
 		polls: 'Yes',
-		forwarding: 'Yes',
+		forwarding: 'No',
 		appEmoji: 'Yes',
 		componentsV2: 'Yes'
 	},

--- a/libs.ts
+++ b/libs.ts
@@ -680,6 +680,46 @@ export const libs: Lib[] = [
 		componentsV2: 'No'
 	},
 	{
+		name: 'Tempest',
+		url: 'https://github.com/amatsagu/tempest',
+		language: 'Go',
+		apiVer: 10,
+		gwVer: '-',
+		voiceVer: '-',
+		slashCommands: 'Yes',
+		buttons: 'Yes',
+		selectMenus: 'Yes',
+		threads: 'Yes',
+		guildStickers: {
+			text: "Possible to self-implement",
+			url: "https://pkg.go.dev/github.com/amatsagu/tempest#Rest"
+		},
+		contextMenus: 'Yes',
+		autocomplete: 'Yes',
+		scheduledEvents: {
+			text: "Possible to self-implement",
+			url: "https://pkg.go.dev/github.com/amatsagu/tempest#Rest"
+		},
+		timeouts: 'Yes',
+		modals: 'Yes',
+		permsv2: 'Yes',
+		automod: {
+			text: "Possible to self-implement",
+			url: "https://pkg.go.dev/github.com/amatsagu/tempest#Rest"
+		},
+		localization: 'Yes',
+		forums: {
+			text: "Possible to self-implement",
+			url: "https://pkg.go.dev/github.com/amatsagu/tempest#Rest"
+		},
+		monetization: 'Partial',
+		userApps: 'Yes',
+		polls: 'Yes',
+		forwarding: 'Yes',
+		appEmoji: 'Yes',
+		componentsV2: 'Yes'
+	},
+	{
 		name: 'Calamity',
 		url: 'https://github.com/simmsb/calamity',
 		language: 'Haskell',


### PR DESCRIPTION
Hey, I've been recommended to add our library onto your list. It's HTTPS based lib (I belive only actively maintained for Go), so we don't have gateway or voice elements, hope I filled all fields properly. Our lib is on Discord documentation page in community libraries section, here github link: https://github.com/amatsagu/tempest

Have a nice day!