### PR TITLE
DiscordPHP supports voice api v8

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -1412,7 +1412,7 @@ export const libs: Lib[] = [
 		language: 'PHP',
 		apiVer: 10,
 		gwVer: 10,
-		voiceVer: 1,
+		voiceVer: 8,
 		slashCommands: 'Yes',
 		buttons: 'Yes',
 		selectMenus: 'Yes',


### PR DESCRIPTION
This pull request makes a small update to the `libs.ts` file, specifically updating the `voiceVer` property for a PHP library from version 1 to version 8.

See https://github.com/discord-php/DiscordPHP/blob/master/src/Discord/Voice/VoiceClient.php#L394