### PR TITLE
fix: mark D4J as supporting E2EE voice

### DIFF
--- a/libs.ts
+++ b/libs.ts
@@ -800,7 +800,7 @@ export const libs: Lib[] = [
 		language: 'Java',
 		apiVer: 10,
 		gwVer: 10,
-		voiceVer: 4,
+		voiceVer: 'E2EE',
 		slashCommands: 'Yes',
 		buttons: 'Yes',
 		selectMenus: 'Yes',


### PR DESCRIPTION
Was done in https://github.com/Discord4J/Discord4J/pull/1344 and publish on April 3rd in version [3.3.2](https://github.com/Discord4J/Discord4J/releases/tag/3.3.2)